### PR TITLE
Update NetUtils.java

### DIFF
--- a/util/src/main/java/com/zfoo/util/net/NetUtils.java
+++ b/util/src/main/java/com/zfoo/util/net/NetUtils.java
@@ -114,9 +114,12 @@ public class NetUtils {
             // 给定的IP未在指定端口范围中
             return false;
         }
-        try (ServerSocket ss = new ServerSocket(port)) {
+        try {
+            InetAddress localHost = InetAddress.getLocalHost();
+            ServerSocket ss = new ServerSocket(port, 50, localHost);
+            ss.close();
             return true;
-        } catch (IOException e) {
+        } catch (Exception e) {
             return false;
         }
     }


### PR DESCRIPTION

Fixes #无法检测本地端口时候被占用
创建 ServerSocket 时 指定本地ip
端口被占用抛出异常为 java.net.BindException: Address already in use (Bind failed)