### PR TITLE
为index注解添加添加MongoDB 的ttl属性,并设置过期时间,单位秒,当设置ttl=true时检验索引数据类型只能是Data类型

### DIFF
--- a/orm/src/main/java/com/zfoo/orm/model/anno/Index.java
+++ b/orm/src/main/java/com/zfoo/orm/model/anno/Index.java
@@ -26,4 +26,8 @@ public @interface Index {
     boolean ascending();
 
     boolean unique();
+
+    boolean ttl() default false;;
+
+    long expireAfterSeconds() default 0L;
 }

--- a/orm/src/main/java/com/zfoo/orm/model/vo/IndexDef.java
+++ b/orm/src/main/java/com/zfoo/orm/model/vo/IndexDef.java
@@ -25,10 +25,17 @@ public class IndexDef {
     private boolean ascending;
     private boolean unique;
 
-    public IndexDef(Field field, boolean ascending, boolean unique) {
+    private boolean ttl;
+
+    private long expireAfterSeconds;
+
+
+    public IndexDef(Field field, boolean ascending, boolean unique, boolean ttl, long expireAfterSeconds) {
         this.field = field;
         this.ascending = ascending;
         this.unique = unique;
+        this.ttl = ttl;
+        this.expireAfterSeconds = expireAfterSeconds;
     }
 
     public Field getField() {
@@ -53,5 +60,21 @@ public class IndexDef {
 
     public void setUnique(boolean unique) {
         this.unique = unique;
+    }
+
+    public boolean isTtl() {
+        return ttl;
+    }
+
+    public void setTtl(boolean ttl) {
+        this.ttl = ttl;
+    }
+
+    public long getExpireAfterSeconds() {
+        return expireAfterSeconds;
+    }
+
+    public void setExpireAfterSeconds(long expireAfterSeconds) {
+        this.expireAfterSeconds = expireAfterSeconds;
     }
 }


### PR DESCRIPTION
为index注解添加添加MongoDB 的ttl属性,并设置过期时间,单位秒,当设置ttl=true时检验索引数据类型只能是Data类型