### PR TITLE
[Protocol, Gdscript] (Fix) wrong writeIntLongMap

### DIFF
--- a/protocol/src/main/resources/gdscript/buffer/ByteBuffer.gd
+++ b/protocol/src/main/resources/gdscript/buffer/ByteBuffer.gd
@@ -469,7 +469,7 @@ func writeIntLongMap(map):
 	else:
 		writeInt(map.size())
 		for key in map:
-			writeInt(map)
+			writeInt(key)
 			writeLong(map[key])
 			
 func readIntLongMap():


### PR DESCRIPTION
Write `key` instead of `map` in `writeIntLongMap` function