### PR TITLE
perf[graalvm]: optimized annotation @GraalvmNativeStorage

### DIFF
--- a/storage/src/main/java/com/zfoo/storage/anno/GraalvmNativeStorage.java
+++ b/storage/src/main/java/com/zfoo/storage/anno/GraalvmNativeStorage.java
@@ -13,6 +13,7 @@
 package com.zfoo.storage.anno;
 
 import org.springframework.aot.hint.annotation.Reflective;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.stereotype.Component;
 
 import java.lang.annotation.*;
@@ -32,6 +33,7 @@ public @interface GraalvmNativeStorage {
     /**
      * graalvm build must specify resource path
      */
+    @AliasFor(annotation=Component.class)
     String value();
 
 }


### PR DESCRIPTION
当前版本启动有warn日志
```
2024-02-27 14:10:36 [ WARN] [main] org.springframework.context.annotation.AnnotationBeanNameGenerator.determineBeanNameFromAnnotation(AnnotationBeanNameGenerator.java:154) - Support for convention-based stereotype names is deprecated and will be removed in a future version of the framework. Please annotate the 'value' attribute in @com.zfoo.storage.anno.GraalvmNativeStorage with @AliasFor(annotation=Component.class) to declare an explicit alias for @Component's 'value' attribute.
```