### PR TITLE
fix[cache]: fixed a bug where expired data could not be deleted

### DIFF
--- a/scheduler/src/main/java/com/zfoo/scheduler/util/LazyCache.java
+++ b/scheduler/src/main/java/com/zfoo/scheduler/util/LazyCache.java
@@ -85,6 +85,9 @@ public class LazyCache<K, V> {
         var cacheValue = new CacheValue<V>();
         cacheValue.value = value;
         cacheValue.expireTime = TimeUtils.now() + expireAfterAccessMillis;
+        if (cacheValue.expireTime < this.minExpireTime) {
+            this.minExpireTime = cacheValue.expireTime;
+        }
         var oldCacheValue = cacheMap.put(key, cacheValue);
         if (oldCacheValue != null) {
             removeListener.accept(List.of(new Pair<>(key, oldCacheValue.value)), RemovalCause.REPLACED);


### PR DESCRIPTION
LazyCache所有数据都过期后minExpireTime被设置为Long.MAX_VALUE，但put方法中没有更新minExpireTime，导致冷数据缓存无法被删除